### PR TITLE
Update get.yaml

### DIFF
--- a/spec/paths/position/get.yaml
+++ b/spec/paths/position/get.yaml
@@ -10,7 +10,7 @@ summary: History
 description: |
   Retrieves either opened, closed or all positions.
 
-  **If no parameters is sent, the opened positions are fetched by default.**
+  **If no parameters are sent, all positions are fetched.**
 operationId: Position_getPositionList
 
 parameters:


### PR DESCRIPTION
Currently a get/positions returns 2 lists, both open and closed. PR adjusts docs to match current API behaviour.